### PR TITLE
Added message templating and corrected for Seq v2

### DIFF
--- a/Seq.App.HipChat/HipChatReactor.cs
+++ b/Seq.App.HipChat/HipChatReactor.cs
@@ -136,7 +136,7 @@ namespace Seq.App.HipChat
 
         private string FormatValue(object value, string format)
         {
-            var rawValue = value.ToString();
+            var rawValue = value != null ? value.ToString() : "(Null)";
 
             if (string.IsNullOrWhiteSpace(format))
             {

--- a/Seq.App.HipChat/HipChatReactor.cs
+++ b/Seq.App.HipChat/HipChatReactor.cs
@@ -65,10 +65,7 @@ namespace Seq.App.HipChat
                 if (!string.IsNullOrWhiteSpace(BaseUrl))
                 {
                     msg.AppendLine();
-                    msg.AppendLine(
-                        string.Format(
-                            "<a href=\"{0}/#/now?filter=@Id%20%3D%3D%20%22{1}%22&show=expanded\">Click here to open in Seq</a>",
-                            BaseUrl, evt.Id));
+                    msg.AppendLine(GenerateSeqUrl(evt));
                 }
 
                 var color = Color;
@@ -95,6 +92,11 @@ namespace Seq.App.HipChat
                         .Error("Could not send HipChat message, server replied {StatusCode} {StatusMessage}: {Message}", Convert.ToInt32(response.StatusCode), response.StatusCode, await response.Content.ReadAsStringAsync());
                 }
             }
+        }
+
+        private string GenerateSeqUrl(Event<LogEventData> evt)
+        {
+            return string.Format("<a href=\"{0}/#/events?filter=@Id%20%3D%3D%20%22{1}%22&show=expanded\">Click here to open in Seq</a>", BaseUrl, evt.Id);
         }
     }
 }

--- a/Seq.App.HipChat/HipChatReactor.cs
+++ b/Seq.App.HipChat/HipChatReactor.cs
@@ -120,9 +120,11 @@ namespace Seq.App.HipChat
         {
             var data = evt.Data;
             var eventType = evt.EventType;
+            var level = data.Level;
 
             var placeholders = data.Properties.ToDictionary(k => k.Key.ToLower(), v => v.Value);
 
+            AddValueIfKeyDoesntExist(placeholders, "Level", level);
             AddValueIfKeyDoesntExist(placeholders, "EventType", eventType);
             AddValueIfKeyDoesntExist(placeholders, "RenderedMessage", data.RenderedMessage);
 

--- a/Seq.App.HipChat/HipChatReactor.cs
+++ b/Seq.App.HipChat/HipChatReactor.cs
@@ -157,9 +157,10 @@ namespace Seq.App.HipChat
 
         private static void AddValueIfKeyDoesntExist(Dictionary<string, object> placeholders, string key, object value)
         {
-            if (!placeholders.ContainsKey(key))
+            var loweredKey = key.ToLower();
+            if (!placeholders.ContainsKey(loweredKey))
             {
-                placeholders.Add(key.ToLower(), value);
+                placeholders.Add(loweredKey, value);
             }
         }
 

--- a/Seq.App.HipChat/HipChatReactor.cs
+++ b/Seq.App.HipChat/HipChatReactor.cs
@@ -15,7 +15,7 @@ namespace Seq.App.HipChat
     Description = "Sends log events to HipChat.")]
     public class HipChatReactor : Reactor, ISubscribeTo<LogEventData>
     {
-        static Regex placeholdersRx = new Regex("(\\[(?<key>[^\\[\\]]+?)(\\:(?<format>[^\\[\\]]+))?\\])", RegexOptions.CultureInvariant | RegexOptions.Compiled);
+        static Regex placeholdersRx = new Regex("(\\[(?<key>[^\\[\\]]+?)(\\:(?<format>[^\\[\\]]+?))?\\])", RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
         private static IDictionary<LogEventLevel, string> _levelColorMap = new Dictionary<LogEventLevel, string>
         {

--- a/Seq.App.HipChat/HipChatReactor.cs
+++ b/Seq.App.HipChat/HipChatReactor.cs
@@ -123,7 +123,7 @@ namespace Seq.App.HipChat
 
             var placeholders = data.Properties.ToDictionary(k => k.Key.ToLower(), v => v.Value);
 
-            AddValueIfKeyDoesntExist(placeholders, "eventtype", eventType);
+            AddValueIfKeyDoesntExist(placeholders, "EventType", eventType);
             AddValueIfKeyDoesntExist(placeholders, "RenderedMessage", data.RenderedMessage);
 
             return placeholdersRx.Replace(messageTemplateToUse, delegate(Match m)
@@ -159,7 +159,7 @@ namespace Seq.App.HipChat
         {
             if (!placeholders.ContainsKey(key))
             {
-                placeholders.Add(key, value);
+                placeholders.Add(key.ToLower(), value);
             }
         }
 

--- a/Seq.App.HipChat/Seq.App.HipChat.csproj
+++ b/Seq.App.HipChat/Seq.App.HipChat.csproj
@@ -49,6 +49,7 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.1.2\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
+    <Reference Include="System.Runtime" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
I've fixed the url for the latest build of Seq and have also added the ability to use custom placeholders in the message i.e. so you can include information from the error itself rather than just the message.

I've not worked out how I can test this on Seq itself so this will need testing/validation.
