### PR TITLE
Support latest HipChat server

### DIFF
--- a/Seq.App.HipChat/HipChatReactor.cs
+++ b/Seq.App.HipChat/HipChatReactor.cs
@@ -8,6 +8,7 @@ using Seq.Apps;
 using Seq.Apps.LogEvents;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Net;
 
 namespace Seq.App.HipChat
 {
@@ -26,6 +27,13 @@ namespace Seq.App.HipChat
             {LogEventLevel.Error, "red"},
             {LogEventLevel.Fatal, "red"},
         };
+
+        static HipChatReactor()
+        {
+            // HipChat Server 2.0 build 2.0.7, TLS 1.0 fallback has been removed
+            // https://confluence.atlassian.com/hc/hipchat-server-release-notes-608731400.html
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
+        }
 
         [SeqAppSetting(
         DisplayName = "Seq Base URL",


### PR DESCRIPTION
Hi! Please excuse the drive-by PR :-)

We received this bug report relating to the removal of TLS 1.0 support in the latest version of HipChat: http://docs.getseq.net/v3/discuss/582ae4ec4c28ec2700ae864c

The PR makes the suggested change and also protects against unobserved exceptions from an `async void` method.

I will ask whether the changes here are the ones the original reporter made to get the app working successfully.